### PR TITLE
Change converse method second argument

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -123,13 +123,13 @@ class ZorkSkill(MycroftSkill):
         save(self.zork, self.save_file)
         LOG.info('SAVE COMPLETE!')
 
-    def converse(self, utterance, lang):
+    def converse(self, utterances, lang):
         """
             Pass sentence on to the frotz zork interpreter. The commands
             "quit" and "exit" will immediately exit the game.
         """
-        if utterance:
-            utterance = utterance[0]
+        if utterances:
+            utterance = utterances[0]
             if self.playing:
                 if "quit" in utterance or utterance == "exit":
                     self.leave_zork()


### PR DESCRIPTION

#### Description
Change converse method second argument from utterance to utterances to comply with mycroft skill manager.
Fixes crash when trying to parse Zorg commands.

#### Type of PR

- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Try asking Mycroft to go east after starting a game of Zork.

#### Documentation
